### PR TITLE
Install Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "prometheus-client"
 gem "rest-client"
+gem "sentry-ruby"
 
 group :test do
   gem "climate_control"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    sentry-ruby (5.15.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     timecop (0.9.8)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -125,6 +127,7 @@ DEPENDENCIES
   rest-client
   rspec
   rubocop-govuk
+  sentry-ruby
   timecop
   webmock
 

--- a/collect
+++ b/collect
@@ -5,6 +5,7 @@ Bundler.setup(:default)
 
 $LOAD_PATH << "./lib"
 
+require "error"
 require "govuk_sli_collector"
 
-GovukSliCollector.call
+Error.report { GovukSliCollector.call }

--- a/lib/error.rb
+++ b/lib/error.rb
@@ -1,0 +1,32 @@
+require "sentry-ruby"
+
+class Error
+  class << self
+    def catch_and_report(&block)
+      configure
+
+      block.call
+    rescue StandardError => e
+      Sentry.capture_exception(e)
+    end
+
+    def report(&block)
+      configure
+
+      block.call
+    rescue StandardError => e
+      Sentry.capture_exception(e)
+
+      raise e
+    end
+
+  private
+
+    def configure
+      @configure ||= begin
+        Sentry.init
+        true
+      end
+    end
+  end
+end

--- a/lib/govuk_sli_collector.rb
+++ b/lib/govuk_sli_collector.rb
@@ -2,6 +2,6 @@ require "govuk_sli_collector/publishing_latency_sli"
 
 module GovukSliCollector
   def self.call
-    GovukSliCollector::PublishingLatencySli.new.call
+    PublishingLatencySli.new.call
   end
 end

--- a/lib/govuk_sli_collector.rb
+++ b/lib/govuk_sli_collector.rb
@@ -1,7 +1,8 @@
+require "error"
 require "govuk_sli_collector/publishing_latency_sli"
 
 module GovukSliCollector
   def self.call
-    PublishingLatencySli.new.call
+    Error.catch_and_report { PublishingLatencySli.new.call }
   end
 end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -1,0 +1,37 @@
+require "error"
+
+RSpec.describe Error do
+  describe ".catch_and_report" do
+    it "sends any exceptions to Sentry and doesn't let them propagate" do
+      stub_const("SilencedError", Class.new(StandardError))
+
+      allow(Sentry).to receive(:capture_exception)
+
+      expect {
+        described_class.catch_and_report do
+          raise SilencedError, "This error is sent to Sentry and silenced"
+        end
+      }.not_to raise_error
+
+      expect(Sentry).to have_received(:capture_exception)
+        .with(an_instance_of(SilencedError))
+    end
+  end
+
+  describe ".report" do
+    it "sends any exceptions to Sentry but also lets them propagate" do
+      stub_const("NoisyError", Class.new(StandardError))
+
+      allow(Sentry).to receive(:capture_exception)
+
+      expect {
+        described_class.report do
+          raise NoisyError, "This error is sent to Sentry and re-raised"
+        end
+      }.to raise_error(NoisyError)
+
+      expect(Sentry).to have_received(:capture_exception)
+        .with(an_instance_of(NoisyError))
+    end
+  end
+end

--- a/spec/govuk_sli_collector_spec.rb
+++ b/spec/govuk_sli_collector_spec.rb
@@ -1,13 +1,15 @@
 require "govuk_sli_collector"
 
 RSpec.describe GovukSliCollector do
-  it "collects the publishing latency SLI" do
-    publishing_latency_sli = instance_spy(GovukSliCollector::PublishingLatencySli)
-    allow(GovukSliCollector::PublishingLatencySli).to receive(:new)
-      .and_return(publishing_latency_sli)
+  describe "collecting the Publishing Latency SLI" do
+    it "invokes PublishingLatencySli#call" do
+      publishing_latency_sli = instance_spy(GovukSliCollector::PublishingLatencySli)
+      allow(GovukSliCollector::PublishingLatencySli).to receive(:new)
+        .and_return(publishing_latency_sli)
 
-    described_class.call
+      described_class.call
 
-    expect(publishing_latency_sli).to have_received(:call)
+      expect(publishing_latency_sli).to have_received(:call)
+    end
   end
 end

--- a/spec/govuk_sli_collector_spec.rb
+++ b/spec/govuk_sli_collector_spec.rb
@@ -11,5 +11,17 @@ RSpec.describe GovukSliCollector do
 
       expect(publishing_latency_sli).to have_received(:call)
     end
+
+    it "sends any exceptions to Sentry and doesn't let them propagate" do
+      stub_const("SilencedError", Class.new(StandardError))
+      expect(GovukSliCollector::PublishingLatencySli).to receive(:new)
+        .and_raise(SilencedError, "This error is sent to Sentry and silenced")
+
+      expect(Error).to receive(:catch_and_report).and_call_original
+
+      expect {
+        described_class.call
+      }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/jDSDGNyn/814-measure-and-record-our-publishing-latency-sli

* Install the gem
* No need for configuration since it uses [the environment variables that we've set for it](https://github.com/alphagov/govuk-helm-charts/blob/b63f8c576184f9c8d717559870fc692853dc38af/charts/govuk-jobs/templates/govuk-sli-collector-cronjob.yaml#L58-L66)
* Send exceptions to Sentry, choosing whether to stop them propagating any further in the code or to re-raise them and allow them to abort the process

I've tested this in integration (https://govuk.sentry.io/issues/?project=4506338071150592&query=is%3Aresolved&referrer=issue-list&statsPeriod=90d)