### PR TITLE
Update deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy
 
-run-name: Deploy ${{ inputs.gitRef || github.event.release.tag_name  }} to ${{ inputs.environment || 'integration' }}
+run-name: Deploy ${{ inputs.gitRef || github.event.release.tag_name  }} to ${{ inputs.environment || 'production' }}
 
 on:
   workflow_dispatch:
@@ -14,8 +14,8 @@ on:
         required: true
         type: choice
         options:
-        - integration
-        default: 'integration'
+        - production
+        default: 'production'
   release:
     types: [released]
 
@@ -30,12 +30,12 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
   trigger-deploy:
-    name: Trigger deploy to ${{ inputs.environment || 'integration' }}
+    name: Trigger deploy to ${{ inputs.environment || 'production' }}
     needs: build-and-publish-image
     uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yml@main
     with:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
-      environment: ${{ inputs.environment || 'integration' }}
+      environment: ${{ inputs.environment || 'production' }}
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_TOKEN }}
       WEBHOOK_URL: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy
 
-run-name: Deploy ${{ inputs.gitRef || github.event.release.tag_name  }} to integration
+run-name: Deploy ${{ inputs.gitRef || github.event.release.tag_name  }} to ${{ inputs.environment || 'integration' }}
 
 on:
   workflow_dispatch:
@@ -9,6 +9,13 @@ on:
         description: 'Commit, tag or branch name to deploy'
         required: true
         type: string
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        type: choice
+        options:
+        - integration
+        default: 'integration'
   release:
     types: [released]
 
@@ -23,12 +30,12 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
   trigger-deploy:
-    name: Trigger deploy to integration
+    name: Trigger deploy to ${{ inputs.environment || 'integration' }}
     needs: build-and-publish-image
     uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yml@main
     with:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
-      environment: integration
+      environment: ${{ inputs.environment || 'integration' }}
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_TOKEN }}
       WEBHOOK_URL: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy
 
-run-name: Deploy ${{ inputs.gitRef || github.ref_name  }} to integration
+run-name: Deploy ${{ inputs.gitRef || github.event.release.tag_name  }} to integration
 
 on:
   workflow_dispatch:
@@ -14,11 +14,11 @@ on:
 
 jobs:
   build-and-publish-image:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'v')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build and publish image
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
     with:
-      gitRef: ${{ inputs.gitRef || github.ref_name }}
+      gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ In production, it's run from a scheduled task via its `./collect` executable.
 
 `bundle exec rspec`
 
+### Docs
+
+[Deployments](docs/deployments.md)
+
 ## Licence
 
 [MIT License](LICENCE.txt)

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -1,0 +1,24 @@
+# Deployments
+
+## Target environment
+
+This project only runs in production and only has the one target environment for deployments.
+
+For this reason, deployment promotion between environments has no meaning for this project.
+
+## How deployment works
+
+Since the project is run from a scheduled task (a K8s `CronJob`), its deployment process differs slightly from that of our apps and some details might prove useful to be aware of if they're not already familiar to you.
+
+Everytime it's run on its schedule, a new Pod will pull a new copy of this project's Docker image from ECR. This differs from the way apps work in that an app's long-running Pods are reprovisioned with the new image once, during the deployment itself.
+
+As with our other projects, when changes are merged, a new release tag is created and in turn, the changes will be deployed automatically.
+
+## Deploying to integration
+
+Because the scheduled task only usually runs in production, some changes are required to enable a version to be deployed to integration (e.g. for testing),
+
+* "integration" will have to be added to the list of target environments in [this repository's deploy workflow](https://github.com/alphagov/govuk-sli-collector/blob/main/.github/workflows/deploy.yml)
+* [the production Helm charts configuration](https://github.com/alphagov/govuk-helm-charts/blob/1adc5596a3fa5df5b030c8248c338ec0293a4ea7/charts/app-config/values-production.yaml#L1275) will have to be copied into [the equivalent integration file](https://github.com/alphagov/govuk-helm-charts/blob/1adc5596a3fa5df5b030c8248c338ec0293a4ea7/charts/app-config/values-integration.yaml)
+
+(If you only need integration temporarily, don't forget to revert these changes when you're done.)


### PR DESCRIPTION
https://trello.com/c/jDSDGNyn/814-measure-and-record-our-publishing-latency-sli

Headline: deploy to production instead of integration.

Plus some general improvements to the deployment workflow and its documentation (including explaining what it even means to deploy to production, and how to deploy to integration again in future if we feel the need to).

FYI, thanks to Sean, `govuk-sli-collector` is now using `image-tags` again https://github.com/alphagov/govuk-helm-charts/pull/1654, which is why the deploy.yml looks so similar to other projects'.