### PR TITLE
Consume Content Store logs from new location

### DIFF
--- a/lib/govuk_sli_collector/publishing_latency_sli/content_store_events.rb
+++ b/lib/govuk_sli_collector/publishing_latency_sli/content_store_events.rb
@@ -11,7 +11,7 @@ module GovukSliCollector
         govuk_request_ids = matching.map(&:govuk_request_id)
 
         log_event_hashes = logit_search.call(
-          app_name: "content-store-mongo-main",
+          app_name: "content-store",
           govuk_request_ids:,
           route: "content_items#update",
           from_time:,

--- a/spec/govuk_sli_collector/publishing_latency_sli/content_store_events_spec.rb
+++ b/spec/govuk_sli_collector/publishing_latency_sli/content_store_events_spec.rb
@@ -41,7 +41,7 @@ module GovukSliCollector
         ]
 
         expect(logit_search).to have_received(:call).with(
-          app_name: "content-store-mongo-main",
+          app_name: "content-store",
           govuk_request_ids:,
           route: "content_items#update",
           from_time:,


### PR DESCRIPTION
The app name "content-store" was being squatted by the Content Store Proxy for that past few months, so we've been consuming Content Store log data using its temporary name, "content-store-mongo-main". The proxy was removed from production today*, leaving the "content-store" app name referring to the real Content Store, so we need to update how we query Logit.

*https://github.com/alphagov/govuk-helm-charts/pull/1598

https://trello.com/c/jDSDGNyn/814-measure-and-record-our-publishing-latency-sli
