### PR TITLE
Add CodeQL (SAST) & Dependency Review (SCA) to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
 
 jobs:
+  codeql-sast:
+    name: CodeQL SAST scan
+    uses: alphagov/govuk-infrastructure/.github/workflows/codeql-analysis.yml@main
+    permissions:
+      security-events: write
+
+  dependency-review:
+    name: Dependency Review scan
+    uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main
+
   lint-ruby:
     name: Lint Ruby
     uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main


### PR DESCRIPTION
I've copied this from one of last month's semi-automated commits that were rolled out to all of our repositories. (This repository wasn't created/we hadn't run the necessary Terraform Cloud script at the time.)

The original message read:

> Add CodeQL (SAST) scan and Dependency Review (SCA) scan to CI pipeline
>
> https://trello.com/c/gbGaKLLu/3352-add-sca-and-sast-scans-to-all-govuk-repos-2
