### PR TITLE
Change references to "kubernetes.deployment.name"

### DIFF
--- a/lib/govuk_sli_collector/publishing_latency_sli/logit_search.rb
+++ b/lib/govuk_sli_collector/publishing_latency_sli/logit_search.rb
@@ -23,7 +23,7 @@ module GovukSliCollector
             query: {
               bool: {
                 filter: [
-                  { term: { "kubernetes.deployment.name": app_name } },
+                  { term: { "kubernetes.labels.app_kubernetes_io/name": app_name } },
                   { term: { "kubernetes.container.name": "app" } },
                   (
                     if route.is_a?(Array)

--- a/spec/govuk_sli_collector/publishing_latency_sli/logit_search_spec.rb
+++ b/spec/govuk_sli_collector/publishing_latency_sli/logit_search_spec.rb
@@ -46,7 +46,7 @@ module GovukSliCollector
         expect(
           logs_request.with do |request|
             expect(filters(request)).to include(
-              { "term" => { "kubernetes.deployment.name" => "thing-publisher" } },
+              { "term" => { "kubernetes.labels.app_kubernetes_io/name" => "thing-publisher" } },
             )
           end,
         ).to have_been_requested


### PR DESCRIPTION
Done due to an update to filebeat that disables logging of `kubernetes.deployment.name` by platform engineering.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
