### PR TITLE
Give deploy workflow id-token permission

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,8 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
+    permissions:
+      id-token: write
   trigger-deploy:
     name: Trigger deploy to ${{ inputs.environment || 'production' }}
     needs: build-and-publish-image


### PR DESCRIPTION
This is required to start using an IAM role instead of long-lived credentials in the image push workflow
alphagov/govuk-infrastructure#1113