### PR TITLE
Add contents: read permission to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
       gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     permissions:
       id-token: write
+      contents: read
   trigger-deploy:
     name: Trigger deploy to ${{ inputs.environment || 'production' }}
     needs: build-and-publish-image


### PR DESCRIPTION
Required as the reusable workflow now needs explicit permissions

For reference: https://github.com/alphagov/publishing-api/pull/2628

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
