### PR TITLE
Pass packages write permission to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write
   trigger-deploy:
     name: Trigger deploy to ${{ inputs.environment || 'production' }}
     needs: build-and-publish-image


### PR DESCRIPTION
This is needed to push images to ghcr.io
