### PR TITLE
Increase the size of histogram buckets

### DIFF
--- a/lib/govuk_sli_collector/publishing_latency_sli/record_metrics.rb
+++ b/lib/govuk_sli_collector/publishing_latency_sli/record_metrics.rb
@@ -1,6 +1,8 @@
 module GovukSliCollector
   class PublishingLatencySli
     class RecordMetrics
+      BUCKETS = [1, 5, 15, 30, 60, 2 * 60, 5 * 60, 10 * 60].freeze
+
       def initialize(prometheus_registry:)
         @prometheus_registry = prometheus_registry
       end
@@ -11,10 +13,12 @@ module GovukSliCollector
         first_content = prometheus_registry.histogram(
           :publishing_latency_first_content_s,
           docstring: "Publishing latency for a single content item, in seconds",
+          buckets: BUCKETS,
         )
         all_content = prometheus_registry.histogram(
           :publishing_latency_all_content_s,
           docstring: "Publishing latency for all affected content items, in seconds",
+          buckets: BUCKETS,
         )
 
         content_store_events_by_id = content_store_events.group_by(&:govuk_request_id)


### PR DESCRIPTION
We should have more histogram buckets at longer time spans (e.g. 1 min to 5 mins, 5 mins to 10 mins, 10 mins to 30 mins, 30 mins to 1 hour) and less at shorter time spans. For publishing latency, we basically don't care how fast it is if it's less than 1 second, but 1 hour is a lot worse than 1 minute. Currently the buckets just group everything longer than 10s as "somewhere between 10 seconds and infinity".

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.